### PR TITLE
feat: allow esc to cancel speed test

### DIFF
--- a/SpeedTest/Community.PowerToys.Run.Plugin.SpeedTest/LoadingWindow.xaml.cs
+++ b/SpeedTest/Community.PowerToys.Run.Plugin.SpeedTest/LoadingWindow.xaml.cs
@@ -7,6 +7,8 @@ using System.Windows.Media.Animation;
 using System.Windows.Threading;
 using System.Windows.Controls;
 using System.Windows.Media;
+using System.Threading;
+using System.Windows.Input;
 
 namespace Community.PowerToys.Run.Plugin.SpeedTest
 {
@@ -15,6 +17,7 @@ namespace Community.PowerToys.Run.Plugin.SpeedTest
         private TestStage _currentStage = TestStage.Connecting;
         private DispatcherTimer _dotAnimationTimer;
         private bool _isCompleted = false;
+        private readonly CancellationTokenSource _cancellationTokenSource;
 
         public enum TestStage
         {
@@ -26,10 +29,22 @@ namespace Community.PowerToys.Run.Plugin.SpeedTest
             Error = 5
         }
 
-        public LoadingWindow()
+        public LoadingWindow(CancellationTokenSource cancellationTokenSource = null)
         {
             InitializeComponent();
+            _cancellationTokenSource = cancellationTokenSource;
             Loaded += LoadingWindow_Loaded;
+            PreviewKeyDown += LoadingWindow_PreviewKeyDown;
+        }
+
+        private void LoadingWindow_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                _cancellationTokenSource?.Cancel();
+                CloseWithAnimation();
+                e.Handled = true;
+            }
         }
 
         private void LoadingWindow_Loaded(object sender, RoutedEventArgs e)

--- a/SpeedTest/Community.PowerToys.Run.Plugin.SpeedTest/ResultsWindow.xaml.cs
+++ b/SpeedTest/Community.PowerToys.Run.Plugin.SpeedTest/ResultsWindow.xaml.cs
@@ -7,6 +7,7 @@ using Microsoft.Win32; // For Registry
 using System;
 using System.Windows.Interop;
 using System.Runtime.InteropServices;
+using System.Windows.Input;
 
 namespace Community.PowerToys.Run.Plugin.SpeedTest
 {
@@ -30,12 +31,22 @@ namespace Community.PowerToys.Run.Plugin.SpeedTest
 
             // Flash the window when it's loaded
             this.Loaded += (s, e) => FlashWindow(new WindowInteropHelper(this).Handle, true);
+            PreviewKeyDown += ResultsWindow_PreviewKeyDown;
 
             #if DEBUG
             // Log the result data for debugging purposes.
             Debug.WriteLine("ResultsWindow: DataContext set. Result Object Debug Info:");
             Debug.WriteLine(_result.GetDebugInfo()); // Assumes GetDebugInfo() is a comprehensive string representation
             #endif
+        }
+
+        private void ResultsWindow_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                Close();
+                e.Handled = true;
+            }
         }
 
         private void ApplyTheme()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to the PowerToys Run SpeedTest Plugin will be documented in 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Pressing `Esc` now cancels a running speed test or closes the results window
+
 ## [1.0.5] - 2025-01-14
 
 ### Added

--- a/docs/README.md
+++ b/docs/README.md
@@ -109,10 +109,11 @@
    - Configure clipboard settings in PowerToys settings if needed
 
 ## 🚀 Usage     
-- Open PowerToys Run (`Alt+Space`)    
+- Open PowerToys Run (`Alt+Space`)
 - Type `spt` and select `Run Speed Test`
 - Enjoy the beautiful loading animation and view real-time progress
 - Results window will flash when complete to get your attention
+- Press `Esc` at any time to cancel the test or close the results window
 - Configure clipboard settings in PowerToys settings
 - Click the result URL to view/share your result online
 


### PR DESCRIPTION
## Summary
- allow cancelling a running test via Esc
- close results window on Esc
- document Esc shortcut and update changelog
